### PR TITLE
Use sha512sum and show reproducible or not output

### DIFF
--- a/repro.sh
+++ b/repro.sh
@@ -116,5 +116,10 @@ done
 echo "Delete snapshot for build2..."
 btrfs subvolume delete "$build_directory/build2"
 
-sha256sum -b build1.tar.xz
-sha256sum -b build2.tar.xz
+sha512sum -b build1.tar.xz | read build1_checksum _
+sha512sum -b build2.tar.xz | read build2_checksum _
+if [ "$build1_checksum" = "$build2_checksum" ]; then
+  echo "Reproducible package!"
+else
+  echo "Not reproducible!"
+fi


### PR DESCRIPTION
sha512sum is faster then sha256sum, therefore use the sha512sum. Also
show if the result was reproducible or not in a friendly way.