### PR TITLE
Polish up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,29 @@
 PROGNM = devtools-repro
-PREFIX ?= /usr
-SHRDIR ?= $(PREFIX)/share
+PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
-LIBDIR ?= $(PREFIX)/lib
-DOCSDIR ?= $(SHRDIR)/doc
+DOCDIR ?= $(PREFIX)/share/doc
+MANDIR ?= $(PREFIX)/share/man
 CONFDIR ?= /etc
+MANS = $(basename $(wildcard docs/*.txt))
 
 all: man repro
-man: docs/repro.8 docs/repro.conf.5
+man: $(MANS)
+$(MANS):
 
-repro.%:
-	a2x --no-xmllint --asciidoc-opts="-f docs/asciidoc.conf" -d manpage -f manpage -D docs $@.txt
+docs/repro.%: docs/repro.%.txt docs/asciidoc.conf
+	a2x --no-xmllint --asciidoc-opts="-f docs/asciidoc.conf" -d manpage -f manpage -D docs $<
 
 repro: repro.in
 	m4 -DREPRO_CONFIG_DIR=$(CONFDIR)/$(PROGNM) $< >$@
 
 install: repro man
-	@install -Dm755 repro	-t $(DESTDIR)$(BINDIR)
-	@install -Dm644 conf/*   -t $(DESTDIR)$(CONFDIR)/$(PROGNM)
-	@install -Dm644 examples/*   -t $(DESTDIR)$(SHRDIR)/$(PROGNM)
-	@install -Dm644 docs/repro.8   -t $(DESTDIR)$(SHRDIR)/man/man8
-	@install -Dm644 docs/repro.conf.5   -t $(DESTDIR)$(SHRDIR)/man/man5
-	@install -Dm644 LICENSE -t $(DESTDIR)$(SHRDIR)/licenses/$(PROGNM)
+	install -Dm755 repro -t $(DESTDIR)$(BINDIR)
+	install -Dm644 conf/* -t $(DESTDIR)$(CONFDIR)/$(PROGNM)
+	install -Dm644 examples/*   -t $(DESTDIR)$(DOCDIR)/$(PROGNM)
+	for manfile in $(MANS); do \
+		install -Dm644 $$manfile -t $(DESTDIR)$(MANDIR)/man$${manfile##*.}; \
+	done;
+	install -Dm644 LICENSE -t $(DESTDIR)$(SHRDIR)/licenses/$(PROGNM)
+
+clean:
+	rm -f repro $(MANS)


### PR DESCRIPTION
manpages should depend on their input -- otherwise Make considers them
up to date as soon as the file by the same name exists. This sort of
works as they are indeed filenames, but they never get updated when
their source files do.

Install all manpages automatically and autodetect their man section.
Adding new manpages should be as simple as creating the right source
file in docs/ and detecting it via wildcard.

The default PREFIX shall always be /usr/local -- if someone wants to
install this outside of a package manager, the fact that it is meant to
interact with distro packages is not justification for installing
untracked files directly to /usr/{bin,share} by default.

Add clean target to provide some way of cleaning generated files which
doesn't rely on assuming a git checkout for `git clean`.

Don't squelch Make's status messages for commands run in the install
target. It is inconsistent with what is done for every other target.