### PR TITLE
performance improvements

### DIFF
--- a/buildinfo
+++ b/buildinfo
@@ -53,20 +53,24 @@ function parse_line () {
 	esac
 }
 
+# Desc: Parses buildinfo from string into current global state
+# STDIN: .BUILDINFO
+function parse () {
+	while read -r line; do
+		parse_line "${line}"
+	done
+}
+
 # Desc: Parses buildinfo from file into current global state
 # 1: .BUILDINFO path
 function parse_buildinfo () {
-	while read -r line; do
-		parse_line "${line}"
-	done < "${1}"
+	parse < "${1}"
 }
 
 # Desc: Parses buildinfo from provided package into current global state
 # 1: Package path
 function parse_package () {
-	while read -r line; do
-		parse_line "${line}"
-	done <<< "$(tar xOf "${1}" .BUILDINFO 2>/dev/null)"
+	parse <<< "$(tar xOf "${1}" .BUILDINFO 2>/dev/null)"
 }
 
 readonly archive_url="https://archive.archlinux.org/packages"

--- a/buildinfo
+++ b/buildinfo
@@ -24,19 +24,11 @@ declare -i format=1 builddate
 declare -a buildenv options installed
 declare pkgname pkgbase pkgver pkgbuild_sha256sum packager builddir
 
-# 1: line
-# 2: field index (starts at 1)
-# Return: field value
-function get_field () {
-	awk -F' = ' "{print \$${2}}" <<< "${1}"
-}
-
 # Desc: Parses line into current global state
 # 1: line
 # Return: nothing
 function parse_line () {
-	key=$(get_field "${1}" 1)
-	val=$(get_field "${1}" 2)
+	IFS=$' = ' read key val <<< "${1}"
 
 	case "${key}" in
 	"format")

--- a/buildinfo
+++ b/buildinfo
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2155
 
 # Copyright (c) 2018 Robin Broda <robin@broda.me>
 #

--- a/buildinfo
+++ b/buildinfo
@@ -111,7 +111,7 @@ function download_archive_package () {
 		local pwd="$(pwd)"
 		local workdir="$(mktemp -d)"
 		local target="$(select_archive_link "${1}")"
-		cd "${workdir}"
+		cd "${workdir}" || exit 1
 		if verify_archive_link "${target}"; then
 			echo "Downloading ${filename}" >&2
 			curl -L "${target}" -o "${filename}" 2>/dev/null
@@ -125,7 +125,7 @@ function download_archive_package () {
 				exit 1
 			fi
 		fi
-		cd "${pwd}"
+		cd "${pwd}" || exit 1
 		rm -r "${workdir}"
 	fi
 }

--- a/buildinfo
+++ b/buildinfo
@@ -149,6 +149,10 @@ while [ "$#" -gt 1 ]; do
 		action="field"
 		shift 1
 		;;
+	-ff)
+		action="field_all"
+		shift 1
+		;;
 	-*)
 		echo "unknown option: ${1}" >&2
 		exit 1
@@ -192,6 +196,14 @@ case "${action}" in
 	;;
 "field")
     echo -e "${!1}"
+	;;
+"field_all")
+	for field in pkgname pkgbase pkgver pkgbuild_sha256sum packager builddate builddir; do
+		echo -e "${field}=${data[${field}]}"
+	done
+	echo -e "buildenv=${buildenv[*]}"
+	echo -e "options=${options[*]}"
+	echo -e "installed=${installed[*]}"
 	;;
 "download")
 	if [ "$#" -gt 0 ]; then

--- a/buildinfo
+++ b/buildinfo
@@ -102,7 +102,7 @@ function verify_archive_link () {
 # 2: Target directory
 function download_archive_package () {
 	local filename="${1}.pkg.tar.xz"
-	local cachedir=$(readlink -e ${2})
+	local cachedir=$(readlink -e "${2}")
 	if [[ -f "${cachedir}/${filename}" ]]; then
 		echo "Hit cache for ${filename}" >&2
 		echo "${2}/${filename}"

--- a/buildinfo
+++ b/buildinfo
@@ -94,7 +94,7 @@ function select_archive_link () {
 
 # 1: Package archive link
 function verify_archive_link () {
-	curl -IfLlso /dev/null "${1}" 
+	curl -IfLlso /dev/null "${1}"
 	return $?
 }
 

--- a/buildinfo
+++ b/buildinfo
@@ -22,7 +22,7 @@
 
 declare -i format=1 builddate
 declare -a buildenv options installed
-declare pkgname pkgbase pkgver pkgbuild_sha256sum packager builddir
+declare -A data
 
 # Desc: Parses line into current global state
 # 1: line
@@ -36,19 +36,13 @@ function parse_line () {
 			echo "incompatible format (want ${format}, got ${val})" >&2
 			exit 1
 		fi
+		data["${key}"]="${val}"
 		;;
-	"pkgname") pkgname="${val}";;
-	"pkgbase") pkgbase="${val}";;
-	"pkgver") pkgver="${val}";;
-	"pkgbuild_sha256sum") pkgbuild_sha256sum="${val}";;
-	"packager") packager="${val}";;
-	"builddate") builddate="${val}";;
-	"builddir") builddir="${val}";;
 	"buildenv") buildenv+=("${val}");;
 	"options") options+=("${val}");;
 	"installed") installed+=("${val}");;
 	*)
-		echo "key '${key}' unimplemented" >&2
+		data["${key}"]="${val}"
 		;;
 	esac
 }
@@ -88,7 +82,7 @@ function get_archive_links () {
 # 1: Package
 function select_archive_link () {
 	for pkgarch in x86_64 any; do
-		local links="$(get_archive_links "${1}" "${pkgarch}")"
+		local links="$(get_archive_links "${1}" "${data[pkgarch]}")"
 		for link in ${links}; do
 			if verify_archive_link "${link}"; then
 				echo "${link}"
@@ -179,13 +173,13 @@ fi
 
 case "${action}" in
 "info")
-	echo -e "Name               : ${pkgname}"
-	echo -e "Base Name          : ${pkgbase}"
-	echo -e "Version            : ${pkgver}"
-	echo -e "Checksum (sha256)  : ${pkgbuild_sha256sum}"
-	echo -e "Packager           : ${packager}"
-	echo -e "Build Date         : ${builddate}"
-	echo -e "Build Directory    : ${builddir}"
+	echo -e "Name               : ${data[pkgname]}"
+	echo -e "Base Name          : ${data[pkgbase]}"
+	echo -e "Version            : ${data[pkgver]}"
+	echo -e "Checksum (sha256)  : ${data[pkgbuild_sha256sum]}"
+	echo -e "Packager           : ${data[packager]}"
+	echo -e "Build Date         : ${data[builddate]}"
+	echo -e "Build Directory    : ${data[builddir]}"
 	echo -e "Build Environment  : ${buildenv[*]}"
 	echo -e "Options            : ${options[*]}"
 	echo -e "Installed Packages : ${#installed[@]}"

--- a/buildinfo
+++ b/buildinfo
@@ -28,7 +28,7 @@ declare pkgname pkgbase pkgver pkgbuild_sha256sum packager builddir
 # 1: line
 # Return: nothing
 function parse_line () {
-	IFS=$' = ' read key val <<< "${1}"
+	IFS=$' = ' read -r key val <<< "${1}"
 
 	case "${key}" in
 	"format")

--- a/buildinfo
+++ b/buildinfo
@@ -195,7 +195,20 @@ case "${action}" in
 	done
 	;;
 "field")
-    echo -e "${!1}"
+	case "${1}" in
+	"buildenv")
+		echo -e "${buildenv[*]}"
+		;;
+	"options")
+		echo -e "${options[*]}"
+		;;
+	"installed")
+		echo -e "${installed[*]}"
+		;;
+	*)
+	    echo -e "${!1}"
+		;;
+	esac
 	;;
 "field_all")
 	for field in pkgname pkgbase pkgver pkgbuild_sha256sum packager builddate builddir; do

--- a/repro.in
+++ b/repro.in
@@ -347,14 +347,19 @@ cmd_check(){
     msg "Starting build..."
     create_snapshot "build" 0
     build="build"
-    
-    packager=$(buildinfo -f "${pkg}" "packager")
-    builddir=$(buildinfo -f "${pkg}" "builddir")
-    builddate=$(buildinfo -f "${pkg}" "builddate")
-    _pkgver=$(buildinfo -f "${pkg}" "pkgver")
+
+    declare -A buildinfo
+    while IFS=$'=' read key value; do
+        [[ "${key}" = [#!]* ]] || [[ "${key}" = "" ]] || binfo["${key}"]="${value}"
+    done <<< "$(buildinfo -ff "${pkg}")"
+
+    packager="${buildinfo[packager]}"
+    builddir="${buildinfo[builddir]}"
+    builddate="${buildinfo[builddate]}"
+    _pkgver="${buildinfo[pkgver]}"
     # pkgrel=${_pkgver##*-}
     # pkgver=${_pkgver%-*}
-    # pkgbase=$(buildinfo -f "${pkg}" "pkgbase")
+    # pkgbase=${buildinfo[pkgbase]}
     pkgver=20171213
     pkgrel=1
     pkgbase="archlinux-keyring"


### PR DESCRIPTION
Various patches, mostly performance related, and a new option for `buildinfo`.

`buildinfo -ff [...]` acts like `buildinfo -f` but spits out all fields including their keys in the format `key=val` delimited by linebreaks, this is so that repro has to invoke buildinfo only once for retrieving various things

these patches combined improve the speed of `buildinfo` about 100x, and the initialization of `repro check` by 400x (timed on large buildinfos with huge `installed`):

![2018-05-05 013140 iridium](https://user-images.githubusercontent.com/8442384/39660159-3ebd73ea-5039-11e8-8856-9f2dfee9c214.png)
![2018-05-05 013219 iridium](https://user-images.githubusercontent.com/8442384/39660161-410df07a-5039-11e8-8355-75768f803e0d.png)

