### PR TITLE
Verify that a pkg.tar.xz was pased to cmd_check

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -324,8 +324,13 @@ cmd_build(){
 cmd_check(){
     local pkg="${1}"
     local cachedir="cache"
-    check_root
 
+    if [[ ! -f "${pkg}" ]]; then
+      error "no pkg.tar.xz given"
+      exit 1
+    fi
+
+    check_root
 
     trap - ERR INT
 


### PR DESCRIPTION
Instead of erroring when setting the build, verify if an actual
file was passed to repro check.