### PR TITLE
Fix buildinfo -f

### DIFF
--- a/buildinfo
+++ b/buildinfo
@@ -191,7 +191,7 @@ case "${action}" in
 		echo -e "${installed[*]}"
 		;;
 	*)
-	    echo -e "${!1}"
+	    echo -e "${data[${1}]}"
 		;;
 	esac
 	;;


### PR DESCRIPTION
if the argument to -f was not either `buildenv`, `options`, or `installed`, it would silently fail