### PR TITLE
Read the last argument as buildinfo file/pkg to fix argument ordering

### DIFF
--- a/buildinfo
+++ b/buildinfo
@@ -153,8 +153,8 @@ if [[ "${action}" == "" ]]; then
 	exit 1
 fi
 
-declare file="$(readlink -e "${1}")"
-shift 1
+declare file="$(readlink -e "${@: -1}")"
+set -- "${@:1:$(($#-1))}"
 if [[ "${file}" =~ \.pkg ]]; then
 	parse_package "${file}"
 else


### PR DESCRIPTION
Before this, calls to `buildinfo -f` looked like this:
`buildinfo -f mypkg.pkg.tar.xz pkgbuild_sha256sum`
with this patch, that would change to
`buildinfo -f pkgbuild_sha256sum mypkg.pkg.tar.xz` - which is much saner