### PR TITLE
conf: Enable multilib by default

### DIFF
--- a/conf/pacman.conf
+++ b/conf/pacman.conf
@@ -86,6 +86,9 @@ Include = /etc/pacman.d/mirrorlist
 [community]
 Include = /etc/pacman.d/mirrorlist
 
+[multilib]
+Include = /etc/pacman.d/mirrorlist
+
 # An example of a custom package repository.  See the pacman manpage for
 # tips on creating your own repositories.
 #[custom]


### PR DESCRIPTION
Enable multilib to be able to reproduce all of our pacakges even in
[multilib] easily.

Closes: #41