### PR TITLE
Uninstall fixes

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -267,7 +267,7 @@ __END__
     read -r -a buildinfo_packages <<< "$(buildinfo -f installed "${pkg}")"
     uninstall=$(comm -13 \
         <(printf '%s\n' "${buildinfo_packages[@]}" | rev | cut -d- -f4- | rev | sort) \
-        <(exec_nspawn build --bind="$(readlink -e ${cachedir}):/cache" pacman -Qq))
+        <(exec_nspawn build --bind="$(readlink -e ${cachedir}):/cache" pacman -Qq | sort))
 
     exec_nspawn build pacman -Rdd --noconfirm -- $uninstall
 

--- a/repro.in
+++ b/repro.in
@@ -269,7 +269,9 @@ __END__
         <(printf '%s\n' "${buildinfo_packages[@]}" | rev | cut -d- -f4- | rev | sort) \
         <(exec_nspawn build --bind="$(readlink -e ${cachedir}):/cache" pacman -Qq | sort))
 
-    exec_nspawn build pacman -Rdd --noconfirm -- $uninstall
+    if [ -n "$uninstall" ]; then
+        exec_nspawn build pacman -Rdd --noconfirm -- $uninstall
+    fi
 
     build_package "build" "$builddir"
     remove_snapshot "build"


### PR DESCRIPTION
- comm is complaining about pacman -Qq output not being sorted correctly
- skip pacman -Rdd if we don't have to uninstall anything