### PR TITLE
Use --ephemeral to prevent nspawn from locking root.scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ docs/repro.%: docs/repro.%.txt docs/asciidoc.conf
 
 repro: repro.in
 	m4 -DREPRO_CONFIG_DIR=$(CONFDIR)/$(PROGNM) $< >$@
+	chmod +x $@
 
 .PHONY: install
 install: repro man

--- a/repro.in
+++ b/repro.in
@@ -84,6 +84,7 @@ function error() {
 function exec_nspawn(){
     local container=$1
     systemd-nspawn -q \
+		--ephemeral \
 		--as-pid2 \
 		--register=no \
 		--pipe \


### PR DESCRIPTION
This should allow multiple repro's running at the same time.