### PR TITLE
Allow setting an archive cache in buildinfo script

### DIFF
--- a/buildinfo
+++ b/buildinfo
@@ -69,7 +69,7 @@ function parse_package () {
 	parse <<< "$(tar xOf "${1}" .BUILDINFO 2>/dev/null)"
 }
 
-readonly archive_url="https://archive.archlinux.org/packages"
+readonly archive_url="${ARCH_ARCHIVE_CACHE:-https://archive.archlinux.org/packages}"
 
 # Desc: get ALA link for given package
 # 1: Package


### PR DESCRIPTION
I'm currently running a cache at `https://cache.rebuilder.fzylab.net/packages` that is faster than `https://archive.archlinux.org/packages` because it follows the redirect to archive.org internally and tries to answer the request from cache if possible.

The cache can be configured with:

    mkdir -p /root/.config/archlinux-repro
    echo export ARCH_ARCHIVE_CACHE=https://cache.rebuilder.fzylab.net/packages >> /root/.config/archlinux-repro/repro.conf
