### PR TITLE
Allow setting MAKEFLAGS in repro.conf and default to -j$(nproc)

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -224,6 +224,7 @@ function cmd_check(){
     SOURCE_DATE_EPOCH="${buildinfo[builddate]}"
 
     {
+        printf 'MAKEFLAGS="%s"\n' "${MAKEFLAGS:--j$(nproc)}"
         printf 'PKGDEST=/pkgdest\n'
         printf 'SRCPKGDEST=/srcpkgdest\n'
         printf 'BUILDDIR=%s\n' "${builddir}"


### PR DESCRIPTION
This significantly speeds up rebuilds. Resolves #67 