### PR TITLE
Exit when an unsupported BUILDINFO is found

### DIFF
--- a/buildinfo
+++ b/buildinfo
@@ -205,7 +205,7 @@ case "${action}" in
 	esac
 	;;
 "field_all")
-	for field in pkgname pkgbase pkgver pkgbuild_sha256sum packager builddate builddir; do
+	for field in pkgname pkgbase pkgver pkgbuild_sha256sum packager builddate builddir format; do
 		echo -e "${field}=${data[${field}]}"
 	done
 	echo -e "buildenv=${buildenv[*]}"

--- a/repro.in
+++ b/repro.in
@@ -283,12 +283,18 @@ function cmd_check(){
     pkgbase=${buildinfo[pkgbase]}
     options=${buildinfo[options]}
     buildenv=${buildinfo[buildenv]}
+    format=${buildinfo[format]}
 
     pkgbuild_sha256sum="${buildinfo[pkgbuild_sha256sum]}"
     SOURCE_DATE_EPOCH="${buildinfo[builddate]}"
 
 
     local build="${pkgbase}_$$"
+
+    if [[ ${format} -ne 1 ]]; then
+      error "unsupported BUILDINFO format or no format definition found, aborting rebuild"
+      exit 1
+    fi
 
     msg2 "Preparing packages"
     mkdir -p "${cachedir}"


### PR DESCRIPTION
Older versions of the BUILDINFO format have no pkgbase and can't be
rebuild. These packages should be rebuild!

Signed-off-by: Jelle van der Waa <jelle@archlinux.org>