### PR TITLE
Drop setsid

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -208,7 +208,7 @@ install -d -o builduser -g builduser /pkgdest
 install -d -o builduser -g builduser /srcpkgdest
 install -d -o builduser -g builduser /build
 __END__
-    exec_nspawn "$build" $args setsid -f -c -w sudo -iu builduser bash -c ". /etc/profile; cd /startdir; SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH makepkg -sc --noconfirm --skippgpcheck $cmds"
+    exec_nspawn "$build" $args sudo -iu builduser bash -c ". /etc/profile; cd /startdir; SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH makepkg -sc --noconfirm --skippgpcheck $cmds"
     mkdir -p "./build"
     for pkgfile in "$BUILDDIRECTORY/$build"/pkgdest/*; do
         mv "$pkgfile" "./build/"


### PR DESCRIPTION
This is applying the patch from #82 by @yan12125. There's been some discussion in #archlinux-reproducible and I'm still not sure what's the perfect solution for our problem, but dropping setsid seems to make repro easier to use. Preferably the build should never probe `/dev/console` since it could be different from the system the binary is actually going to run on. Let me know what you think!

Resolves #82 and https://github.com/kpcyrd/rebuilderd/issues/28