### PR TITLE
Rework repro container handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ docs/repro.%: docs/repro.%.txt docs/asciidoc.conf
 
 repro: repro.in
 	m4 -DREPRO_CONFIG_DIR=$(CONFDIR)/$(PROGNM) $< >$@
+	chmod 755 $@
 
 .PHONY: install
 install: repro man

--- a/repro.in
+++ b/repro.in
@@ -49,7 +49,7 @@ function init_gnupg() {
     # ensure signing key is available
     # We try WKD first, then fallback to keyservers.
     # This works on debian./
-    gpg --keyserver=p80.pool.sks-keyservers.net --auto-key-locate wkd,keyserver --locate-keys pierre@archlinux.de
+    gpg --keyserver=p80.pool.sks-keyservers.net --auto-key-locate wkd,keyserver --locate-keys pierre@archlinux.de &>/dev/null
 }
 
 # Desc: Sets the appropriate colors for output

--- a/repro.in
+++ b/repro.in
@@ -232,7 +232,7 @@ function init_chroot(){
         touch "$BUILDDIRECTORY/root/.repro-1"
         lock_close 9
     else
-      if [ ! -d "$BUILDDIRECTORY/root/.repro-1" ]; then
+      if [ ! -f "$BUILDDIRECTORY/root/.repro-1" ]; then
         error "Please delete $BUILDDIRECTORY and initialize the chroots again"
         exit 1
       fi

--- a/repro.in
+++ b/repro.in
@@ -7,6 +7,8 @@ fi
 
 BUILDDIRECTORY=/var/lib/repro
 
+KEYRINGCACHE="${BUILDDIRECTORY}/keyring"
+
 BOOTSTRAPMIRROR=https://mirror.archlinux.no/iso/latest
 readonly bootstrap_img=archlinux-bootstrap-"$(date +%Y.%m)".01-"$(uname -m)".tar.gz
 CONFIGDIR='REPRO_CONFIG_DIR'
@@ -118,16 +120,14 @@ lock() {
 ##
 #  usage : slock( $fd, $file, $message, [ $message_arguments... ] )
 ##
-slock() {
+nlock() {
     # Only reopen the FD if it wasn't handed to us
     if ! [[ "/dev/fd/$1" -ef "$2" ]]; then
         mkdir -p -- "$(dirname -- "$2")"
         eval "exec $1>"'"$2"'
     fi
 
-    if ! flock -sn "$1"; then
-        flock -s "$1"
-    fi
+    flock "$1"
 }
 
 ##
@@ -148,6 +148,7 @@ function exec_nspawn(){
     systemd-nspawn -q \
       --as-pid2 \
       --register=no \
+      ${EPHEMERAL:+--ephemeral} \
       --pipe \
       -E "PATH=/usr/local/sbin:/usr/local/bin:/usr/bin" \
       -D "$BUILDDIRECTORY/$container" "${@:2}"
@@ -272,6 +273,8 @@ function cmd_check(){
     options=${buildinfo[options]}
     buildenv=${buildinfo[buildenv]}
     format=${buildinfo[format]}
+    installed=${buildinfo[installed]}
+
 
     pkgbuild_sha256sum="${buildinfo[pkgbuild_sha256sum]}"
     SOURCE_DATE_EPOCH="${buildinfo[builddate]}"
@@ -287,8 +290,6 @@ function cmd_check(){
     msg2 "Finished preparing packages"
 
     msg "Starting build..."
-    slock 9 "$BUILDDIRECTORY"/root.lock
-
     local build="${pkgbase}_$$"
     create_snapshot "$build" 0
 
@@ -296,7 +297,7 @@ function cmd_check(){
 
     # Father I have sinned
     if ((!pkgbuild_file)); then
-    exec_nspawn root --bind="${build_root_dir}/startdir:/startdir" --bind="$(readlink -e ${cachedir}):/var/cache/pacman/pkg" \
+    EPHEMERAL=1 exec_nspawn root --bind="${build_root_dir}/startdir:/startdir" --bind="$(readlink -e ${cachedir}):/var/cache/pacman/pkg" \
     bash <<-__END__
 shopt -s globstar
 pacman -S asp devtools --noconfirm
@@ -309,8 +310,6 @@ for rev in \$(git rev-list --all -- repos/); do
     if [ \$pkgbuild_checksum = $pkgbuild_sha256sum ]; then
         git checkout \$rev
         mv ./trunk/* /startdir
-        popd
-        rm -rf $pkgbase
         exit 0
     fi
 done
@@ -331,10 +330,36 @@ __END__
     packages=(${packages[@]##*/})
     packages=(${packages[@]/#/cache\/})
 
+    # shellcheck disable=SC2086
+    keyring_package="$(printf -- '%s\n' ${installed[*]} | grep -E "archlinux-keyring")"
+
+    if [ ! -d "$KEYRINGCACHE/$keyring_package" ]; then
+      msg2 "Setting up $keyring_package in keyring cache, this might take a while..."
+
+      nlock 9 "$KEYRINGCACHE/$keyring_package.lock"
+      # shellcheck disable=SC2086
+      keyring=$(printf -- '%s\n' ${packages[*]} | grep -E "archlinux-keyring")
+      EPHEMERAL=1 exec_nspawn root --bind="${build_root_dir}:/mnt" --bind="$(readlink -e "${cachedir}"):/cache" bash -c \
+          'pacstrap -U /mnt "$@"' -bash "${keyring}" &>/dev/null
+
+      mkdir -p "$KEYRINGCACHE/$keyring_package"
+      EPHEMERAL=1 exec_nspawn root \
+        --bind="$KEYRINGCACHE/$keyring_package:/mnt" \
+        --bind="${build_root_dir}/usr/share/pacman/keyrings:/usr/share/pacman/keyrings" \
+        -E PACMAN_KEYRING_DIR=/mnt \
+        bash -c 'pacman-key --init && pacman-key --populate archlinux' &>/dev/null
+      lock_close 9 "$KEYRINGCACHE/$keyring_package.lock"
+    else
+      msg2 "Found $keyring_package in keyring cache"
+    fi
+
     msg "Installing packages"
     # shellcheck disable=SC2086
-    exec_nspawn "root" --bind="${build_root_dir}:/mnt" --bind="$(readlink -e ${cachedir}):/cache" bash -c \
-        'pacstrap -U /mnt "$@"' -bash "${packages[@]}"
+    EPHEMERAL=1 exec_nspawn root \
+      --bind="${build_root_dir}:/mnt" \
+      --bind-ro="$KEYRINGCACHE/$keyring_package:/etc/pacman.d/gnupg" \
+      --bind="$(readlink -e ${cachedir}):/cache" bash -c \
+      'pacstrap -G -U /mnt --needed "$@"' -bash "${packages[@]}"
 
     # Setup environment
     {
@@ -362,7 +387,6 @@ __END__
     build_package "$build" "$builddir"
     remove_snapshot "$build"
     chown -R "$src_owner" "${cachedir}"
-    lock_close 9
 
     msg "Comparing hashes..."
     if diff -q -- "$pkg" ./build/"$(basename "$pkg")" > /dev/null ; then
@@ -443,5 +467,6 @@ shift $((OPTIND-1))
 check_root NOCHECK,MAKEFLAGS,DEBUG,CACHEDIR
 init_gnupg
 test -d "$BUILDDIRECTORY"/root || get_bootstrap_img
+test -d "$KEYRINGCACHE" || mkdir -p "$KEYRINGCACHE"
 init_chroot
 cmd_check "$@"

--- a/repro.in
+++ b/repro.in
@@ -229,9 +229,13 @@ function init_chroot(){
         exec_nspawn root pacman-key --init &> /dev/null
         exec_nspawn root pacman-key --populate archlinux &> /dev/null
         exec_nspawn root pacman -Sy
+        touch "$BUILDDIRECTORY/root/.repro-1"
         lock_close 9
     else
-
+      if [ ! -d "$BUILDDIRECTORY/root/.repro-1" ]; then
+        error "Please delete $BUILDDIRECTORY and initialize the chroots again"
+        exit 1
+      fi
       if lock 9 "$BUILDDIRECTORY"/root.lock; then
           printf 'Server = %s\n' "$HOSTMIRROR" > "$BUILDDIRECTORY"/root/etc/pacman.d/mirrorlist
           exec_nspawn root pacman -Syu --noconfirm

--- a/repro.in
+++ b/repro.in
@@ -164,10 +164,7 @@ function cleanup_root_volume(){
 function remove_snapshot (){
     local build=$1
     msg2 "Delete snapshot for $build..."
-    umount "$BUILDDIRECTORY/$build" || true
     rm -rf "${BUILDDIRECTORY:?}/${build}"
-    rm -rf "${BUILDDIRECTORY:?}/${build}_upperdir"
-    rm -rf "${BUILDDIRECTORY:?}/${build}_workdir"
     trap - ERR INT
 }
 
@@ -179,11 +176,7 @@ function create_snapshot (){
     trap "{ remove_snapshot \"$build\" ; exit 1; }" ERR INT
 
     msg2 "Create snapshot for $build..."
-    mkdir -p "$BUILDDIRECTORY/"{"${build}","${build}_upperdir","${build}_workdir"}
-    # shellcheck disable=SC2140
-    mount -t overlay overlay \
-        -o lowerdir="$BUILDDIRECTORY/root",upperdir="$BUILDDIRECTORY/${build}_upperdir",workdir="$BUILDDIRECTORY/${build}_workdir" \
-        "$BUILDDIRECTORY/${build}"
+    mkdir -p "${BUILDDIRECTORY}/${build}/startdir"
     touch "$BUILDDIRECTORY/$build"
 }
 
@@ -234,24 +227,14 @@ function init_chroot(){
         tar xvf "$IMGDIRECTORY/$bootstrap_img" -C "$BUILDDIRECTORY/root" --strip-components=1 > /dev/null
 
         printf 'Server = %s\n' "$HOSTMIRROR" > "$BUILDDIRECTORY"/root/etc/pacman.d/mirrorlist
-        printf '%s.UTF-8 UTF-8\n' en_US de_DE > "$BUILDDIRECTORY"/root/etc/locale.gen
-        printf 'LANG=en_US.UTF-8\n' > "$BUILDDIRECTORY"/root/etc/locale.conf
+        sed -i "s/LocalFileSigLevel.*/LocalFileSigLevel = Never/g" "$BUILDDIRECTORY/root/etc/pacman.conf"
+
 
         systemd-machine-id-setup --root="$BUILDDIRECTORY"/root
         msg2 "Setting up keyring, this might take a while..."
         exec_nspawn root pacman-key --init &> /dev/null
         exec_nspawn root pacman-key --populate archlinux &> /dev/null
-
-        msg2 "Updating and installing base & base-devel"
-        exec_nspawn root pacman -Syu base-devel --noconfirm
-        exec_nspawn root pacman -R arch-install-scripts --noconfirm
-        exec_nspawn root locale-gen
-
-        printf 'builduser ALL = NOPASSWD: /usr/bin/pacman\n' > "$BUILDDIRECTORY"/root/etc/sudoers.d/builduser-pacman
-        exec_nspawn root useradd -m -G wheel -s /bin/bash -d /build builduser
-        echo "keyserver-options auto-key-retrieve" | install -Dm644 /dev/stdin "$BUILDDIRECTORY/root"/build/.gnupg/gpg.conf
-        exec_nspawn root chown -R builduser /build/.gnupg
-        exec_nspawn root chmod 700 /build/.gnupg
+        exec_nspawn root pacman -Sy
         lock_close 9
     else
 
@@ -297,9 +280,6 @@ function cmd_check(){
     pkgbuild_sha256sum="${buildinfo[pkgbuild_sha256sum]}"
     SOURCE_DATE_EPOCH="${buildinfo[builddate]}"
 
-
-    local build="${pkgbase}_$$"
-
     if [[ ${format} -ne 1 ]]; then
       error "unsupported BUILDINFO format or no format definition found, aborting rebuild"
       exit 1
@@ -312,25 +292,29 @@ function cmd_check(){
 
     msg "Starting build..."
     slock 9 "$BUILDDIRECTORY"/root.lock
+
+    local build="${pkgbase}_$$"
     create_snapshot "$build" 0
+
+    local build_root_dir="$BUILDDIRECTORY/${build}"
 
     # Father I have sinned
     if ((!pkgbuild_file)); then
-    exec_nspawn "$build" --bind="$(readlink -e ${cachedir}):/var/cache/pacman/pkg" \
+    exec_nspawn root --bind="${build_root_dir}/startdir:/startdir" --bind="$(readlink -e ${cachedir}):/var/cache/pacman/pkg" \
     bash <<-__END__
 shopt -s globstar
-install -d -o builduser -g builduser /startdir
 pacman -S asp devtools --noconfirm
 cp /usr/share/devtools/makepkg-x86_64.conf /etc/makepkg.conf
 asp checkout $pkgbase
-cd $pkgbase
+pushd $pkgbase
 for rev in \$(git rev-list --all -- repos/); do
     pkgbuild_checksum=\$(git show \$rev:trunk/PKGBUILD | sha256sum -b)
     pkgbuild_checksum=\${pkgbuild_checksum%% *}
     if [ \$pkgbuild_checksum = $pkgbuild_sha256sum ]; then
         git checkout \$rev
         mv ./trunk/* /startdir
-        pacman -Rs asp devtools --noconfirm
+        popd
+        rm -rf $pkgbase
         exit 0
     fi
 done
@@ -346,6 +330,16 @@ __END__
     exit 1
   fi
 
+    # buildinfo returns packages with absolute paths to the location
+    # this strips the paths and adds "cache/" prefix
+    packages=(${packages[@]##*/})
+    packages=(${packages[@]/#/cache\/})
+
+    msg "Installing packages"
+    # shellcheck disable=SC2086
+    exec_nspawn "root" --bind="${build_root_dir}:/mnt" --bind="$(readlink -e ${cachedir}):/cache" bash -c \
+        'pacstrap -U /mnt "$@"' -bash "${packages[@]}"
+
     # Setup environment
     {
         printf 'MAKEFLAGS="%s"\n' "${MAKEFLAGS:--j$(nproc)}"
@@ -357,32 +351,17 @@ __END__
         printf 'BUILDENV=(%s)\n' "${buildenv}"
         printf 'COMPRESSZST=(zstd -c -T0 --ultra -20 -)\n'
         printf 'PKGEXT=".pkg.tar%s"\n' "${pkg##*tar}"
-     } >> "$BUILDDIRECTORY/$build/etc/makepkg.conf"
-    # We do the signature checking with pacman -Udd
-    sed -i "s/LocalFileSigLevel.*//g" "$BUILDDIRECTORY/$build/etc/pacman.conf"
+     } >> "$build_root_dir/etc/makepkg.conf"
 
+    printf '%s.UTF-8 UTF-8\n' en_US de_DE > "$build_root_dir/etc/locale.gen"
+    printf 'LANG=en_US.UTF-8\n' > "$build_root_dir/etc/locale.conf"
+    exec_nspawn "$build" locale-gen
 
-    # buildinfo returns packages with absolute paths to the location
-    # this strips the paths and adds "cache/" prefix
-    packages=(${packages[@]##*/})
-    packages=(${packages[@]/#/cache\/})
-
-    msg "Installing packages"
-    # shellcheck disable=SC2086
-    exec_nspawn "$build" --bind="$(readlink -e ${cachedir}):/cache" bash -c \
-        'yes y | pacman -Udd --needed --overwrite "*" -- "$@"' -bash "${packages[@]}"
-
-    read -r -a buildinfo_packages <<< "$(buildinfo -f installed "${pkg}")"
-    uninstall=$(comm -13 \
-        <(printf '%s\n' "${buildinfo_packages[@]}" | rev | cut -d- -f4- | rev | sort) \
-        <(exec_nspawn "$build" --bind="$(readlink -e ${cachedir}):/cache" pacman -Qq | sort))
-
-    if [ -n "$uninstall" ]; then
-        exec_nspawn "$build" pacman -Rdd --noconfirm -- $uninstall
-    fi
-
-    # reinstall all packages - fixes overwritten files and installs with correct dependency order
-    exec_nspawn "$build" --bind="$(readlink -e ${cachedir}):/cache" pacman -U --noconfirm -- "${packages[@]}"
+    printf 'builduser ALL = NOPASSWD: /usr/bin/pacman\n' > "$build_root_dir/etc/sudoers.d/builduser-pacman"
+    exec_nspawn "$build" useradd -m -s /bin/bash -d /build builduser
+    echo "keyserver-options auto-key-retrieve" | install -Dm644 /dev/stdin "$build_root_dir/build/.gnupg/gpg.conf"
+    exec_nspawn "$build" chown -R builduser /build/.gnupg /startdir
+    exec_nspawn "$build" chmod 700 /build/.gnupg
 
     build_package "$build" "$builddir"
     remove_snapshot "$build"

--- a/repro.in
+++ b/repro.in
@@ -173,9 +173,7 @@ function remove_snapshot (){
 # 1: name of container
 function create_snapshot (){
     local build="$1"
-
     trap "{ remove_snapshot \"$build\" ; exit 1; }" ERR INT
-
     msg2 "Create snapshot for $build..."
     mkdir -p "${BUILDDIRECTORY}/${build}/startdir"
     touch "$BUILDDIRECTORY/$build"

--- a/repro.in
+++ b/repro.in
@@ -222,8 +222,7 @@ function init_chroot(){
         tar xvf "$IMGDIRECTORY/$bootstrap_img" -C "$BUILDDIRECTORY/root" --strip-components=1 > /dev/null
 
         printf 'Server = %s\n' "$HOSTMIRROR" > "$BUILDDIRECTORY"/root/etc/pacman.d/mirrorlist
-        sed -i "s/LocalFileSigLevel.*/LocalFileSigLevel = Never/g" "$BUILDDIRECTORY/root/etc/pacman.conf"
-
+        sed -i "s/LocalFileSigLevel.*//g" "$BUILDDIRECTORY/root/etc/pacman.conf"
 
         systemd-machine-id-setup --root="$BUILDDIRECTORY"/root
         msg2 "Setting up keyring, this might take a while..."

--- a/repro.in
+++ b/repro.in
@@ -187,10 +187,6 @@ function build_package(){
     local build=$1
     local builddir=${2:-"/startdir"}
     local args=""
-    local cmds=""
-    if ((NOCHECK)); then
-      cmds="--nocheck"
-    fi
     if ((pkgbuild_file)); then
       args=--bind="${PWD}:/startdir"
     fi
@@ -201,7 +197,7 @@ install -d -o builduser -g builduser /pkgdest
 install -d -o builduser -g builduser /srcpkgdest
 install -d -o builduser -g builduser /build
 __END__
-    exec_nspawn "$build" $args sudo -iu builduser bash -c ". /etc/profile; cd /startdir; SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH makepkg -sc --noconfirm --skippgpcheck $cmds"
+    exec_nspawn "$build" $args sudo -iu builduser bash -c ". /etc/profile; cd /startdir; SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH makepkg -sc --noconfirm --skippgpcheck ${NOCHECK:+--nocheck}"
     mkdir -p "./build"
     for pkgfile in "$BUILDDIRECTORY/$build"/pkgdest/*; do
         mv "$pkgfile" "./build/"


### PR DESCRIPTION
Instead of creating containers with overlayfs with the bootstrap image as base, this introduces the bootstrap container only as a pivot to run `pacstrap` into the empty directory with the fetched packages. This reduces some complexity except for the keyring handling, which we would have to deal with anyway.

This also introduces a keyring cache as initializing keyrings all the time takes some time.

The net result is some reduced complexity, and the container creating being twice as fast.