### PR TITLE
repro: fix handling of NOCHECK=0

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -23,7 +23,7 @@ trap "{ rm -r $IMGDIRECTORY; }" EXIT
 DIFFOSCOPE="diffoscope"
 
 # Turn on/off check in repro
-NOCHECK=${NOCHECK:-""}
+: "${NOCHECK:=0}"
 
 CACHEDIR="${CACHEDIR:-cache}"
 
@@ -196,7 +196,7 @@ install -d -o builduser -g builduser /pkgdest
 install -d -o builduser -g builduser /srcpkgdest
 install -d -o builduser -g builduser /build
 __END__
-    exec_nspawn "$build" $args sudo -iu builduser bash -c ". /etc/profile; cd /startdir; SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH makepkg -sc --noconfirm --skippgpcheck ${NOCHECK:+--nocheck}"
+    exec_nspawn "$build" $args sudo -iu builduser bash -c ". /etc/profile; cd /startdir; SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH makepkg -sc --noconfirm --skippgpcheck $( (( NOCHECK )) && echo --nocheck)"
     mkdir -p "./build"
     for pkgfile in "$BUILDDIRECTORY/$build"/pkgdest/*; do
         mv "$pkgfile" "./build/"


### PR DESCRIPTION
- The `-n` argument/`NOCHECK` configuration option has been broken since commit 1a84c11fd19ff87daf460c10878037595a9995d7 ("repro: Remove the ugly NOCHECK logic for inline args"), never executing tests regardless of whether the option was specified or not.
- Commit 14784c6e66daa33999bb68f2d98e7fb65b5b64e6 ("repro: Ensure NOCHECK works properly.") recently fixed the handling of the `-n` argument and the `NOCHECK=1` configuration option, executing tests by default unless this option is specified. However, `NOCHECK=0` skips tests as well, which is not the intended behaviour according to the repro man page.
- This commit uses real evaluation of the value of NOCHECK again to run test if `NOCHECK=0` is given and to skip them with `NOCHECK=1`. This makes it necessary to restore the double-parentheses construct from before commit 1a84c11fd19ff87daf460c10878037595a9995d7 because parameter expansion can only decide on whether a variable is set or not, but not on its value.