### PR TITLE
Correctness/speed improvements

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -301,8 +301,7 @@ function cmd_check(){
     EPHEMERAL=1 exec_nspawn root --bind="${build_root_dir}/startdir:/startdir" --bind="$(readlink -e ${cachedir}):/var/cache/pacman/pkg" \
     bash <<-__END__
 shopt -s globstar
-pacman -S asp devtools --noconfirm
-cp /usr/share/devtools/makepkg-x86_64.conf /etc/makepkg.conf
+pacman -S asp --noconfirm --needed
 asp checkout $pkgbase
 pushd $pkgbase
 for rev in \$(git rev-list --all -- repos/); do

--- a/repro.in
+++ b/repro.in
@@ -237,6 +237,7 @@ function init_chroot(){
         exit 1
       fi
       if lock 9 "$BUILDDIRECTORY"/root.lock; then
+          msg "Reusing existing container"
           printf 'Server = %s\n' "$HOSTMIRROR" > "$BUILDDIRECTORY"/root/etc/pacman.d/mirrorlist
           exec_nspawn root pacman -Syu --noconfirm
           lock_close 9
@@ -298,6 +299,7 @@ function cmd_check(){
 
     # Father I have sinned
     if ((!pkgbuild_file)); then
+    msg2 "Fetching PKGBUILD from ASP..."
     EPHEMERAL=1 exec_nspawn root --bind="${build_root_dir}/startdir:/startdir" --bind="$(readlink -e ${cachedir}):/var/cache/pacman/pkg" \
     bash <<-__END__
 shopt -s globstar

--- a/repro.in
+++ b/repro.in
@@ -228,7 +228,7 @@ function init_chroot(){
         msg2 "Setting up keyring, this might take a while..."
         exec_nspawn root pacman-key --init &> /dev/null
         exec_nspawn root pacman-key --populate archlinux &> /dev/null
-        exec_nspawn root pacman -Sy
+        exec_nspawn root pacman -Syu --noconfirm
         touch "$BUILDDIRECTORY/root/.repro-1"
         lock_close 9
     else


### PR DESCRIPTION
There's a much shorter series adding some correctness/speed improvements. Namely:
 - upon initial enter into the container, we use "pacman -Sy" instead of "pacman -Syu"
 - while fetching the PKGBUILD from ASP, we install devtools and copy makepkg.conf
 - mildly related: add pretty messages for a couple of sections

Former caches some 20+ packages, so the second run is faster by a minute or so, compared to w/o the patch, While the latter patch shaves another ~30 seconds. Tested with zstd, numbers do fluctuate +/-5s with the final runtime at 2:30s.

For anyone curios:
Of the 2:30s total time, one minute is makepkg itself, with the fakeroot package installation another 30s. My suspicion is that the ldconfig in the install scriptlet is being picky.