### PR TITLE
Add version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docs/repro.%: docs/repro.%.txt docs/asciidoc.conf
 	a2x --no-xmllint --asciidoc-opts="-f docs/asciidoc.conf" -d manpage -f manpage -D docs $<
 
 repro: repro.in
-	m4 -DREPRO_CONFIG_DIR=$(CONFDIR)/$(PROGNM) $< >$@
+	m4 -DREPRO_VERSION=$(TAG) -DREPRO_CONFIG_DIR=$(CONFDIR)/$(PROGNM) $< >$@
 	chmod 755 $@
 
 .PHONY: install

--- a/repro.in
+++ b/repro.in
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+VERSION='REPRO_VERSION'
+
 set -eE -o pipefail
 
 if ((DEBUG)); then
@@ -528,14 +531,20 @@ General Options:
  -d                           Run diffoscope if packages are not reproducible
  -f                           Use the local PKGBUILD for building
  -n                           Run makepkg with --nocheck
+ -V                           Print version information
  -o <path>                    Set the output directory (default: ./build)
 __END__
 }
 
+function print_version() {
+    echo "repro ${VERSION}"
+}
+
 function parse_args() {
-    while getopts :hdnf arg; do
+    while getopts :hdnfV arg; do
         case $arg in
             h) print_help; exit 0;;
+            V) print_version; exit 0;;
             f) pkgbuild_file=1;;
             d) run_diffoscope=1;;
             n) NOCHECK=1;;
@@ -589,5 +598,6 @@ colorize
 source_conf
 parse_args "$@"
 check_root NOCHECK,MAKEFLAGS,DEBUG,CACHEDIR
+print_version
 init_chroot
 cmd_check


### PR DESCRIPTION
Very simple patch to add a `-v` flag to print version information. I find myself reaching for it every now and then...

It does require a bump in `repro.in` when a new release is cut, and I don't know if that's a deal breaker.