### PR TITLE
Print error message if no matching PKGBUILD could be found

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -369,6 +369,7 @@ for rev in \$(git rev-list --all -- repos/); do
         exit 0
     fi
 done
+echo "ERROR: Failed to find commit this was built with (PKGBUILD checksum didn't match any commit)" >&2
 exit 1
 __END__
     lock_close 9 "${cachedir}.lock"


### PR DESCRIPTION
It currently looks like this:
```
(4/4) Warn about old perl modules
From https://github.com/archlinux/svntogit-community
 * branch            packages/phpvirtualbox -> FETCH_HEAD
 * [new branch]      packages/phpvirtualbox -> community/packages/phpvirtualbox
Cloning into 'phpvirtualbox'...
done.
/phpvirtualbox /
[1m[34m  ->[0m[1m Delete snapshot for phpvirtualbox_270554...[0m
```
With this patch it should look like this:
```
(4/4) Warn about old perl modules
From https://github.com/archlinux/svntogit-community
 * branch            packages/phpvirtualbox -> FETCH_HEAD
 * [new branch]      packages/phpvirtualbox -> community/packages/phpvirtualbox
Cloning into 'phpvirtualbox'...
done.
/phpvirtualbox /
ERROR: Failed to find commit this was built with (PKGBUILD checksum didn't match any commit)
[1m[34m  ->[0m[1m Delete snapshot for phpvirtualbox_270554...[0m
```