### PR TITLE
Do not print colors if stdout is no tty

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -78,21 +78,32 @@ function init_gnupg() {
 
 # Desc: Sets the appropriate colors for output
 function colorize() {
-    # prefer terminal safe colored and bold text when tput is supported
-    if tput setaf 0 &>/dev/null; then
-        ALL_OFF="$(tput sgr0)"
-        BOLD="$(tput bold)"
-        BLUE="${BOLD}$(tput setaf 4)"
-        GREEN="${BOLD}$(tput setaf 2)"
-        RED="${BOLD}$(tput setaf 1)"
-        YELLOW="${BOLD}$(tput setaf 3)"
+    # test if stdout is a tty
+    if [ -t 1 ]; then
+        # prefer terminal safe colored and bold text when tput is supported
+        if tput setaf 0 &>/dev/null; then
+            ALL_OFF="$(tput sgr0)"
+            BOLD="$(tput bold)"
+            BLUE="${BOLD}$(tput setaf 4)"
+            GREEN="${BOLD}$(tput setaf 2)"
+            RED="${BOLD}$(tput setaf 1)"
+            YELLOW="${BOLD}$(tput setaf 3)"
+        else
+            ALL_OFF="\e[0m"
+            BOLD="\e[1m"
+            BLUE="${BOLD}\e[34m"
+            GREEN="${BOLD}\e[32m"
+            RED="${BOLD}\e[31m"
+            YELLOW="${BOLD}\e[33m"
+        fi
     else
-        ALL_OFF="\e[0m"
-        BOLD="\e[1m"
-        BLUE="${BOLD}\e[34m"
-        GREEN="${BOLD}\e[32m"
-        RED="${BOLD}\e[31m"
-        YELLOW="${BOLD}\e[33m"
+        # stdout is piped, disable colors
+        ALL_OFF=""
+        BOLD=""
+        BLUE=""
+        GREEN=""
+        RED=""
+        YELLOW=""
     fi
     readonly ALL_OFF BOLD BLUE GREEN RED YELLOW
 }


### PR DESCRIPTION
We currently always print color codes, even if stdout/stderr are a pipe instead of a terminal.