### PR TITLE
Use new function name in `buildinfo -p`

### DIFF
--- a/buildinfo
+++ b/buildinfo
@@ -188,7 +188,7 @@ case "${action}" in
 	;;
 "packages")
 	for ipkg in "${installed[@]}"; do
-		select_archive_link "${ipkg}"
+		get_archive_link "${ipkg}"
 	done
 	;;
 "field")


### PR DESCRIPTION
This changes the output of this call 
```
/usr/bin/buildinfo: line 191: select_archive_link: command not found
/usr/bin/buildinfo: line 191: select_archive_link: command not found
/usr/bin/buildinfo: line 191: select_archive_link: command not found
[...]
```
to
```
https://archive.archlinux.org/packages/a/acl/acl-2.3.0-1-x86_64.pkg.tar.
https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20210110-1-any.pkg.tar.
https://archive.archlinux.org/packages/a/attr/attr-2.5.0-1-x86_64.pkg.tar.
[...]
```
note that the extension is still missing, because we can't know that from the buildinfo file.