### PR TITLE
Fix location of devtools-20210202-3-any fallback

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -347,7 +347,7 @@ function cmd_check(){
     DEVTOOLS_PKG="devtools"
     if [[ -z "${BUILDTOOL}" ]] || [[ "${BUILDTOOL}" = makepkg ]]; then
       DEVTOOLS="devtools-20210202-3-any"
-      DEVTOOLS_PKG="$ARCHIVEURL/${BUILDTOOL:0:1}/${DEVTOOLS}.pkg.tar${pkg##*tar}"
+      DEVTOOLS_PKG="$ARCHIVEURL/d/devtools/${DEVTOOLS}.pkg.tar${pkg##*tar}"
     elif [[ "${BUILDTOOL}" = devtools ]] ; then
       DEVTOOLS="${BUILDTOOL}-${BUILDTOOLVER}"
       DEVTOOLS_PKG="$ARCHIVEURL/${BUILDTOOL:0:1}/${DEVTOOLS}.pkg.tar${pkg##*tar}"
@@ -482,6 +482,7 @@ rm --recursive /etc/pacman.d/gnupg/
 cp --target-directory=/etc/pacman.d/ --recursive /gnupg
 echo "faked-system-time ${SOURCE_DATE_EPOCH}" >> /etc/pacman.d/gnupg/gpg.conf
 pacstrap -G -U /mnt --needed "\$@"
+echo "Installing devtools from $DEVTOOLS_PKG"
 # Ignore all dependencies since we only want the file
 # Saves us a few seconds and doesn't download a bunch of things
 # we are getting rid off


### PR DESCRIPTION
```
# ./repro /var/cache/pacman/pkg/which-2.21-5-x86_64.pkg.tar.xz
[...]
(11/12) Updating the info directory file...
(12/12) Rebuilding certificate stores...
Installing devtools from https://archive.archlinux.org/packages/d/devtools/devtools-20210202-3-any.pkg.tar.zst
:: Retrieving packages...
 devtools-20210202-3-any                    41.7 KiB   130 KiB/s 00:00 [#######################################] 100%
loading packages...
looking for conflicting packages...

Packages (1) devtools-20210202-3

Total Installed Size:  0.16 MiB

:: Proceed with installation? [Y/n] 
(1/1) checking keys in keyring                                         [#######################################] 100%
(1/1) checking package integrity                                       [#######################################] 100%
(1/1) loading package files                                            [#######################################] 100%
[...]
==> Checking for packaging issues...
==> Creating package "which"...
  -> Generating .PKGINFO file...
  -> Generating .BUILDINFO file...
warning: database file for 'core' does not exist (use '-Sy' to download)
warning: database file for 'extra' does not exist (use '-Sy' to download)
warning: database file for 'community' does not exist (use '-Sy' to download)
  -> Generating .MTREE file...
  -> Compressing package...
==> Leaving fakeroot environment.
==> Finished making: which 2.21-5 (Sun 16 Jan 2022 03:11:43 PM CET)
==> Cleaning up...
  -> Delete snapshot for which_33120...
==> Comparing hashes...
==> Package is reproducible!
```