### PR TITLE
Mirror and keyring fixes

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -312,7 +312,8 @@ function init_chroot(){
     if nlock 9 "$BUILDDIRECTORY"/root.lock; then
       msg "Updating container"
       printf 'Server = %s\n' "$HOSTMIRROR" > "$BUILDDIRECTORY"/root/etc/pacman.d/mirrorlist
-      exec_nspawn root pacman -Syu --noconfirm
+      exec_nspawn root pacman -Sy --noconfirm --needed archlinux-keyring
+      exec_nspawn root pacman -Su --noconfirm
       lock_close 9
     else
       msg "Couldn't acquire container lock, didn't update."

--- a/repro.in
+++ b/repro.in
@@ -15,12 +15,11 @@ BUILDDIRECTORY=/var/lib/repro
 
 KEYRINGCACHE="${BUILDDIRECTORY}/keyring"
 
-IMG_RELEASE_TIMESTAMP="$(date -d '24 hours ago' -u +%Y.%m)".01
-BOOTSTRAPMIRROR="https://europe.mirror.pkgbuild.com/iso/$IMG_RELEASE_TIMESTAMP"
-readonly bootstrap_img=archlinux-bootstrap-"$IMG_RELEASE_TIMESTAMP"-"$(uname -m)".tar.gz
+BOOTSTRAPMIRROR="https://geo.mirror.pkgbuild.com/iso/latest"
+readonly bootstrap_img=archlinux-bootstrap-"$(uname -m)".tar.gz
 CONFIGDIR='REPRO_CONFIG_DIR'
 
-HOSTMIRROR="https://europe.mirror.pkgbuild.com/\$repo/os/\$arch"
+HOSTMIRROR="https://geo.mirror.pkgbuild.com/\$repo/os/\$arch"
 
 ARCHIVEURL="${ARCH_ARCHIVE_CACHE:-https://archive.archlinux.org/packages}"
 


### PR DESCRIPTION
The first commit updates the bootstrap image URL to use the `latest` symlinks instead of including the date in the filename. This is needed for this month as the ISOs have been [delayed](https://lists.archlinux.org/archives/list/arch-dev-public@lists.archlinux.org/thread/5RIRXL2ZMPIWQCUKNENO7BFMMPOIPKPR/). It also switches to the Geo mirror instead of hardcoding `europe` which might not be the fastest mirror from outside Europe.

The second commit should address the following keyring issue:

```
==> Reusing existing container
==> Updating container
:: Synchronizing package databases...
 core is up to date
 extra is up to date
 community is up to date
:: Starting full system upgrade...
:: Replace hwids with core/hwdata? [Y/n] 
resolving dependencies...
looking for conflicting packages...

Packages (87) acl-2.3.1-2  arch-install-scripts-26-1  archlinux-keyring-20220727-1
              argon2-20190702-4  attr-2.5.1-2  audit-3.0.8-1  bash-5.1.016-1  brotli-1.0.9-8
              ca-certificates-mozilla-3.81-1  coreutils-9.1-1  cryptsetup-2.5.0-1  curl-7.84.0-2
              dbus-1.14.0-1  device-mapper-2.03.16-1  e2fsprogs-1.46.5-4  expat-2.4.8-1
              file-5.42-1  filesystem-2021.12.07-1  findutils-4.9.0-1  gcc-libs-12.1.1-4
              gdbm-1.23-1  gettext-0.21-2  glib2-2.72.3-1  glibc-2.36-1  gmp-6.2.1-2
              gnupg-2.2.36-1  gnutls-3.7.6-1  gpgme-1.17.1-1  grep-3.7-1  hwdata-0.361-1
              hwids-20210613-1 [removal]  iana-etc-20220603-1  icu-71.1-1  iptables-1:1.8.8-2
              json-c-0.16-1  kbd-2.5.1-1  kmod-30-1  krb5-1.19.3-3  libarchive-3.6.1-1
              libcap-2.65-1  libcap-ng-0.8.3-1  libelf-0.187-2  libevent-2.1.12-1
              libffi-3.4.2-5  libgcrypt-1.10.1-1  libgpg-error-1.45-2  libidn2-2.3.3-1
              libldap-2.6.3-1  libmnl-1.0.5-1  libnetfilter_conntrack-1.0.9-1
              libnfnetlink-1.0.2-1  libnftnl-1.2.2-1  libnghttp2-1.48.0-1  libnl-3.7.0-1
              libp11-kit-0.24.1-1  libpcap-1.10.1-2  libsasl-2.1.28-1  libseccomp-2.5.4-1
              libsecret-0.20.5-2  libsysprof-capture-3.44.0-2  libunistring-1.0-1
              libverto-0.3.2-4  libxcrypt-4.4.28-2  libxml2-2.9.14-1
              linux-api-headers-5.18.15-1  mpfr-4.1.0.p13-3  ncurses-6.3-3  nettle-3.8-1
              openssl-1.1.1.q-1  p11-kit-0.24.1-1  pacman-6.0.1-7  pacman-mirrorlist-20220724-1
              pambase-20211210-1  pcre2-10.40-1  popt-1.18-3  readline-8.1.002-1
              shadow-4.11.1-1  sqlite-3.39.1-1  systemd-251.3-1  systemd-libs-251.3-1
              tpm2-tss-3.2.0-1  tzdata-2022a-1  util-linux-2.38-1  util-linux-libs-2.38-1
              xz-5.2.5-3  zlib-1:1.2.12-2  zstd-1.5.2-7

Total Download Size:     0.08 MiB
Total Installed Size:  450.90 MiB
Net Upgrade Size:       70.80 MiB

:: Proceed with installation? [Y/n] 
:: Retrieving packages...
 libcap-2.65-1-x86_64           83.6 KiB   960 KiB/s 00:00 [###############################] 100%
(86/86) checking keys in keyring                           [###############################] 100%
(86/86) checking package integrity                         [###############################] 100%
error: libcap: signature from "David Runge <dvzrv@archlinux.org>" is marginal trust
:: File /var/cache/pacman/pkg/libcap-2.65-1-x86_64.pkg.tar.zst is corrupted (invalid or corrupted package (PGP signature)).
Do you want to delete it? [Y/n] 
error: failed to commit transaction (invalid or corrupted package)
Errors occurred, no packages were upgraded.
```