### PR TITLE
Switch to our Geo mirror and use the latest image

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -15,12 +15,11 @@ BUILDDIRECTORY=/var/lib/repro
 
 KEYRINGCACHE="${BUILDDIRECTORY}/keyring"
 
-IMG_RELEASE_TIMESTAMP="$(date -d '24 hours ago' -u +%Y.%m)".01
-BOOTSTRAPMIRROR="https://europe.mirror.pkgbuild.com/iso/$IMG_RELEASE_TIMESTAMP"
-readonly bootstrap_img=archlinux-bootstrap-"$IMG_RELEASE_TIMESTAMP"-"$(uname -m)".tar.gz
+BOOTSTRAPMIRROR="https://geo.mirror.pkgbuild.com/iso/latest"
+readonly bootstrap_img=archlinux-bootstrap-"$(uname -m)".tar.gz
 CONFIGDIR='REPRO_CONFIG_DIR'
 
-HOSTMIRROR="https://europe.mirror.pkgbuild.com/\$repo/os/\$arch"
+HOSTMIRROR="https://geo.mirror.pkgbuild.com/\$repo/os/\$arch"
 
 ARCHIVEURL="${ARCH_ARCHIVE_CACHE:-https://archive.archlinux.org/packages}"
 


### PR DESCRIPTION
Instead of figuring out the date to use, specify that we want the
latest bootstrap image. Also use geo.mirror.pkgbuild.com for both
the mirror to fetch the image from and the mirror used inside the
container.