### PR TITLE
Stop early on first archive extension that exists

### DIFF
--- a/buildinfo
+++ b/buildinfo
@@ -118,6 +118,7 @@ function download_archive_package () {
 					echo "check ${workdir}" >&2
 					exit 1
 				fi
+				break
 			fi
 		done
 		cd "${pwd}" || exit 1


### PR DESCRIPTION
When a .zst package is downloaded from the archive, there's no point to also check for the same package with a .xz extension. Doing so results in huge delays because archive.archlinux.org redirects to archive.org when a requested file doesn't exist, and archive.org lookups are slow.

Testing on thunar-4.16.11-2, downloads are reduced from 10m36s to 1m39s.