### PR TITLE
Create `$BUILDDIRECTORY/_gnupg` with mode 700

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -71,7 +71,8 @@ function gpg() {
 }
 
 function init_gnupg() {
-    mkdir -p "$BUILDDIRECTORY/_gnupg"
+    mkdir -p "$BUILDDIRECTORY/"
+    mkdir -p --mode 700 "$BUILDDIRECTORY/_gnupg"
 
     # ensure signing key is available
     # We try WKD first, then fallback to keyservers.


### PR DESCRIPTION
Explicitly specify the mode to create the `_gnupg` directory with, to satisfy `gpg`, which otherwise produces the warning:
```
gpg: WARNING: unsafe permissions on homedir '/var/lib/repro/_gnupg'
```