### PR TITLE
Update gpg trusted key

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -77,7 +77,7 @@ function init_gnupg() {
     # ensure signing key is available
     # We try WKD first, then fallback to keyservers.
     # This works on debian./
-    gpg --keyserver=p80.pool.sks-keyservers.net --auto-key-locate wkd,keyserver --locate-keys pierre@archlinux.de
+    gpg --keyserver=p80.pool.sks-keyservers.net --auto-key-locate wkd,keyserver --locate-keys pierre@archlinux.org
 }
 
 # Desc: Sets the appropriate colors for output


### PR DESCRIPTION
Currently, private gpg receive keys from pierre@archlinux.de. However, the latest bootstrap image is signed by pierre@archlinux.org. This patch makes private gpg receive keys from the correct email.