### PR TITLE
fix: use correct makepkg.conf location without silently failing

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -496,11 +496,14 @@ else
   pacman --noconfirm --needed -Sddu "$DEVTOOLS_PKG"
 fi
 
-for makepkg_path in /usr/share/devtools/{makepkg-x86_64.conf,makepkg.d/x86_64.conf}; do
-  if [ -f "\$makepkg_path" ]; then
-    cp -v "\$makepkg_path" /mnt/etc/makepkg.conf
-  fi
-done
+if [[ -f /usr/share/devtools/makepkg.conf.d/x86_64.conf ]]; then
+    cp -v /usr/share/devtools/makepkg.conf.d/x86_64.conf /mnt/etc/makepkg.conf
+elif [[ -f /usr/share/devtools/makepkg-x86_64.conf ]]; then
+    cp -v /usr/share/devtools/makepkg-x86_64.conf /mnt/etc/makepkg.conf
+else
+    echo "Failed to find the makepkg.conf location, please report to archlinux-repro"
+    exit 1
+fi
 __END__
     lock_close 9 "$KEYRINGCACHE/$keyring_package.lock"
 


### PR DESCRIPTION
There was a typo when implementing the new devtools makepkg.conf location. Unfortunately the code failed silently which made it not be detected until now.
Fix this by using the correct location as well as switch to a simple fall-through approach so we can easily fail instead of silently and invisibly doing the wrong thing leading to false-negative unreproducible packages.

Fixes 63ce7514966f28299cfc8e2508e7045e610ee135