### PR TITLE
Fix exit code being ignored for pacstrap

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -481,6 +481,7 @@ __END__
       --bind="$(readlink -e ${cachedir}):/var/cache/pacman/pkg" \
       --bind="$(readlink -e ${cachedir}):/cache" \
       bash -bash "${packages[@]}" <<-__END__
+set -e
 rm --recursive /etc/pacman.d/gnupg/
 cp --target-directory=/etc/pacman.d/ --recursive /gnupg
 echo "faked-system-time ${SOURCE_DATE_EPOCH}" >> /etc/pacman.d/gnupg/gpg.conf


### PR DESCRIPTION
I've noticed two kinds of errors showing up due to pacstrap (silently) failing:

```
==> Installing packages to /mnt
warning: database file for 'core' does not exist (use '-Sy' to download)
warning: database file for 'extra' does not exist (use '-Sy' to download)
error: 'cache/acme-tiny-5.0.1-1-any.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/findutils-4.9.0-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/gawk-5.1.1-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/hwdata-0.358-1-any.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/kbd-2.4.0-2-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/pacman-mirrorlist-20220227-1-any.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/perl-5.34.1-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
loading packages...
==> ERROR: Failed to install packages to new root
Installing devtools from https://archive.archlinux.org/packages/d/devtools-20220207-2-any.pkg.tar.zst
loading packages...
looking for conflicting packages...

Packages (1) devtools-20220207-2

Total Installed Size:  0.19 MiB

:: Proceed with installation? [Y/n] 
checking keyring...
checking package integrity...
loading package files...
checking for file conflicts...
checking available disk space...
:: Processing package changes...
installing devtools...
Optional dependencies for devtools
    btrfs-progs: btrfs support
:: Running post-transaction hooks...
(1/1) Arming ConditionNeedsUpdate...
'/usr/share/devtools/makepkg-x86_64.conf' -> '/mnt/etc/makepkg.conf'
Directory /srv/archlinux-repro/acme-user_2117784 doesn't look like it has an OS tree (/usr/ directory is missing). Refusing.
  -> Delete snapshot for acme-user_2117784...
```

and

```
==> Installing packages to /mnt
warning: database file for 'core' does not exist (use '-Sy' to download)
warning: database file for 'extra' does not exist (use '-Sy' to download)
warning: archlinux-keyring-20210902-1 is up to date -- skipping
error: 'cache/coreutils-8.32-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/diffutils-3.8-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/filesystem-2021.05.31-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/grep-3.6-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/gzip-1.11-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/less-1:590-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/libseccomp-2.5.2-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/lz4-1:1.9.3-2-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/pcre-8.45-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/sed-4.8-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
error: 'cache/tar-1.34-1-x86_64.pkg.tar.zst': invalid or corrupted package (PGP signature)
loading packages...
==> ERROR: Failed to install packages to new root
Installing devtools from https://archive.archlinux.org/packages/d/devtools/devtools-20210202-3-any.pkg.tar.zst
loading packages...
looking for conflicting packages...

Packages (1) devtools-20210202-3

Total Installed Size:  0.16 MiB

:: Proceed with installation? [Y/n] 
checking keyring...
checking package integrity...
loading package files...
checking for file conflicts...
checking available disk space...
:: Processing package changes...
installing devtools...
Optional dependencies for devtools
    btrfs-progs: btrfs support
:: Running post-transaction hooks...
(1/1) Arming ConditionNeedsUpdate...
'/usr/share/devtools/makepkg-x86_64.conf' -> '/mnt/etc/makepkg.conf'
execv(locale-gen) failed: No such file or directory
```

In both cases the script should end after `==> ERROR: Failed to install packages to new root` instead of cryptic error messages about e.g. the `locale-gen` binary or `/usr` missing.