### PR TITLE
Same shebang for repro and buildinfo

### DIFF
--- a/buildinfo
+++ b/buildinfo
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 # shellcheck disable=SC2155
 
 # Copyright (c) 2018 Robin Broda <robin@broda.me>

--- a/repro.in
+++ b/repro.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 VERSION='REPRO_VERSION'
 


### PR DESCRIPTION
buildinfo already uses `#!/usr/bin/env bash`