### PR TITLE
Fix devtools location on archive server

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -369,7 +369,7 @@ function cmd_check(){
       DEVTOOLS_PKG="$ARCHIVEURL/d/devtools/${DEVTOOLS}.pkg.tar.zst"
     elif [[ "${BUILDTOOL}" = devtools ]] ; then
       DEVTOOLS="${BUILDTOOL}-${BUILDTOOLVER}"
-      DEVTOOLS_PKG="$ARCHIVEURL/${BUILDTOOL:0:1}/${DEVTOOLS}.pkg.tar${pkg##*tar}"
+      DEVTOOLS_PKG="$ARCHIVEURL/${BUILDTOOL:0:1}/${BUILDTOOL}/${DEVTOOLS}.pkg.tar${pkg##*tar}"
     fi
     msg2 "Using devtools version: %s" "${DEVTOOLS}"
 


### PR DESCRIPTION
The packages in the archive are always inside a subdirectory. Replicate the fix done for two lines above in
commit 2cb94138f698 ("Fix location of devtools-20210202-3-any fallback")