### PR TITLE
Allow placing upper limit on RAM use on build container

### DIFF
--- a/repro.in
+++ b/repro.in
@@ -219,6 +219,7 @@ function exec_nspawn(){
         --register=no \
         ${EPHEMERAL:+--ephemeral} \
         ${ISSYSTEMD242:+--pipe} \
+        ${MAX_MEMORY:+--property="MemoryMax=${MAX_MEMORY}"} \
         -E "PATH=/usr/local/sbin:/usr/local/bin:/usr/bin" \
         -D "$BUILDDIRECTORY/$container" "${@:2}"
     if ((EPHEMERAL)); then
@@ -582,6 +583,7 @@ General Options:
  -d                           Run diffoscope if packages are not reproducible
  -f                           Use the local PKGBUILD for building
  -n                           Run makepkg with --nocheck
+ -M <value>                   Set an upper limit for RAM use on the build container (e.g. 12G)
  -V                           Print version information
  -o <path>                    Set the output directory (default: ./build)
 __END__
@@ -592,13 +594,14 @@ function print_version() {
 }
 
 function parse_args() {
-    while getopts :hdnfVo: arg; do
+    while getopts :hdnfM:Vo: arg; do
         case $arg in
             h) print_help; exit 0;;
             V) print_version; exit 0;;
             f) pkgbuild_file=1;;
             d) run_diffoscope=1;;
             n) NOCHECK=1;;
+            M) MAX_MEMORY="$OPTARG";;
             o) OUTDIR="$OPTARG";;
             *) error "unknown argument ${OPTARG}" ; print_help; exit 1;;
         esac


### PR DESCRIPTION
This should work according to docs, but I haven't tested this yet.